### PR TITLE
Port the 26.1 branch to Minecraft 26.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,15 +4,15 @@ org.gradle.parallel=true
 org.gradle.configuration-cache=false
 
 # Fabric Properties https://fabricmc.net/develop
-minecraft_version=26.1
-loader_version=0.19.2
-loom_version=1.16-SNAPSHOT
+minecraft_version=26.2
+loader_version=0.19.3
+loom_version=1.17-SNAPSHOT
 
 # Mod Properties
-mod_version=2.4.3
+mod_version=2.4.3+26.2
 maven_group=com.khazoda
 archives_base_name=basicstorage
 
 # Dependencies
-fabric_version=0.144.0+26.1
-sodium_version=0.8.9+mc26.1.1
+fabric_version=0.154.2+26.2
+sodium_version=0.9.2-alpha.3+mc26.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/client/java/com/khazoda/basicstorage/renderer/CrateRenderer.java
+++ b/src/client/java/com/khazoda/basicstorage/renderer/CrateRenderer.java
@@ -7,8 +7,9 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.Font.DisplayMode;
-import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.renderer.SubmitNodeCollector;
+import net.minecraft.client.renderer.block.BlockModelLighter;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
@@ -33,6 +34,7 @@ public class CrateRenderer implements BlockEntityRenderer<CrateBlockEntity, Crat
   private static final Quaternionf ITEM_LIGHT_ROTATION_3D = new Quaternionf().rotateX((float) Math.toRadians(-15)).rotateY((float) Math.toRadians(15));
   private final ItemModelResolver itemModelManager;
   private final Font textRenderer;
+  private final BlockModelLighter blockModelLighter = new BlockModelLighter();
 
   public CrateRenderer(BlockEntityRendererProvider.Context context) {
     this.itemModelManager = context.itemModelResolver();
@@ -55,16 +57,16 @@ public class CrateRenderer implements BlockEntityRenderer<CrateBlockEntity, Crat
     BlockPos pos = be.getBlockPos();
     var world = be.getLevel();
 
-    if (world != null) {
+    if (world instanceof ClientLevel clientLevel) {
       BlockPos neighborPos = pos.relative(facingDir);
-      BlockState neighborState = world.getBlockState(neighborPos);
+      BlockState neighborState = clientLevel.getBlockState(neighborPos);
 
       if (!Block.shouldRenderFace(state, neighborState, facingDir)) {
         crateState.itemRenderState = null;
         crateState.itemCount = 0;
         return;
       }
-      crateState.lightCoords = LevelRenderer.getLightCoords(world, neighborPos);
+      crateState.lightCoords = blockModelLighter.getLightCoords(state, clientLevel, neighborPos);
     }
 
     if (be.storage.isResourceBlank()) {

--- a/src/main/java/com/khazoda/basicstorage/advancement/StationTransformedCriterion.java
+++ b/src/main/java/com/khazoda/basicstorage/advancement/StationTransformedCriterion.java
@@ -2,9 +2,9 @@ package com.khazoda.basicstorage.advancement;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import net.minecraft.advancements.criterion.ContextAwarePredicate;
-import net.minecraft.advancements.criterion.EntityPredicate;
-import net.minecraft.advancements.criterion.SimpleCriterionTrigger;
+import net.minecraft.advancements.predicates.ContextAwarePredicate;
+import net.minecraft.advancements.predicates.entity.EntityPredicate;
+import net.minecraft.advancements.triggers.SimpleCriterionTrigger;
 import net.minecraft.server.level.ServerPlayer;
 
 import java.util.Optional;

--- a/src/main/java/com/khazoda/basicstorage/block/entity/CrateBlockEntity.java
+++ b/src/main/java/com/khazoda/basicstorage/block/entity/CrateBlockEntity.java
@@ -110,7 +110,7 @@ public class CrateBlockEntity extends BlockEntity implements ItemOwner {
   }
 
   public Vec3 position() {
-    return this.getBlockPos().getCenter();
+    return Vec3.atCenterOf(this.getBlockPos());
   }
 
   public float getVisualRotationYInDegrees() {

--- a/src/main/java/com/khazoda/basicstorage/datagen/AdvancementProvider.java
+++ b/src/main/java/com/khazoda/basicstorage/datagen/AdvancementProvider.java
@@ -8,7 +8,7 @@ import net.fabricmc.fabric.api.datagen.v1.provider.FabricAdvancementProvider;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementHolder;
 import net.minecraft.advancements.AdvancementType;
-import net.minecraft.advancements.criterion.InventoryChangeTrigger;
+import net.minecraft.advancements.triggers.InventoryChangeTrigger;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -44,8 +44,8 @@
     }
   },
   "depends": {
-    "fabricloader": ">=0.19.2",
-    "minecraft": ">=26.1 <26.2",
+    "fabricloader": ">=0.19.3",
+    "minecraft": ">=26.2 <26.3",
     "java": ">=25",
     "fabric-api": "*"
   }


### PR DESCRIPTION
This updates the 26.1 branch to Minecraft 26.2.

The changes are version bumps and small API fixes required by 26.2. The advancement predicate and trigger classes moved, BlockPos.getCenter() was removed, and the client light lookup used by the crate renderer changed. The renderer now uses BlockModelLighter for that lookup.

Tested with JDK 25:

./gradlew clean build

The storage and network code is unchanged.